### PR TITLE
Initial JSON support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.iml
 
 pids
 logs
@@ -13,6 +14,7 @@ results
 .idea
 
 npm-debug.log
+package-lock.json
 node_modules
 testing.js
 test/localConfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ lib-cov
 *.out
 *.pid
 *.gz
-*.iml
 
 pids
 logs
@@ -14,7 +13,6 @@ results
 .idea
 
 npm-debug.log
-package-lock.json
 node_modules
 testing.js
 test/localConfig.json

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -781,11 +781,13 @@ function defineInstanceMembers() {
         jsonString = JSON.stringify(value);
     }
 
+    //Get byte length of jsonString
     const jsonStringByteLength = Buffer.byteLength(jsonString);
 
-    //We alloc a buffer that is the size of the jsonString + lengthBufferSize (which  is the length used by getLengthBuffer
+    //Use Unsafe since we are writing in its entirety
     const buffer = utils.allocBufferUnsafe(jsonStringByteLength);
 
+    //Write to buffer (pass length to save a tick)
     buffer.write(jsonString, 0, jsonStringByteLength, 'utf8');
 
     return buffer;

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -286,9 +286,7 @@ function defineInstanceMembers() {
     return map;
   };
   this.decodeJson = function decodeJson(bytes){
-
     return JSON.parse(bytes.toString('utf8'));
-
   };
   this.decodeUuid = function (bytes) {
     return new types.Uuid(this.handleBuffer(bytes));
@@ -1567,6 +1565,9 @@ Encoder.guessDataType = function (value) {
   }
   else if (util.isArray(value)) {
     code = dataTypes.list;
+  }
+  else if ( esTypeName === 'object' &&  Object.prototype.toString.call(value) === '[object Object]' ){
+    code = dataTypes.json;
   }
   if (code === null) {
     return null;

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -285,6 +285,11 @@ function defineInstanceMembers() {
     }
     return map;
   };
+  this.decodeJson = function decodeJson(bytes){
+
+    return JSON.parse(bytes.toString('utf8'));
+
+  };
   this.decodeUuid = function (bytes) {
     return new types.Uuid(this.handleBuffer(bytes));
   };
@@ -751,6 +756,40 @@ function defineInstanceMembers() {
 
     parts.unshift(this.getLengthBuffer(propCounter));
     return Buffer.concat(parts);
+  };
+  this.encodeJson = function encodeJson(value){
+
+    let jsonString;
+
+    //Use a switch to handle other typeof checking in the future
+    switch(typeof value){
+      case 'string':
+        // If valid json was already provided (but stringified) use the provided string
+        // This is valid if a user wants absolute control over the json object they pass for storage
+        // Passing an object as a value would leave some risk of the object being modified by the stack after client.execute() is called
+        try{
+
+          JSON.parse(value);
+
+          jsonString = value;
+
+          break;
+
+        }
+        catch(err){ }
+      default:
+        jsonString = JSON.stringify(value);
+    }
+
+    const jsonStringByteLength = Buffer.byteLength(jsonString);
+
+    //We alloc a buffer that is the size of the jsonString + lengthBufferSize (which  is the length used by getLengthBuffer
+    const buffer = utils.allocBufferUnsafe(jsonStringByteLength);
+
+    buffer.write(jsonString, 0, jsonStringByteLength, 'utf8');
+
+    return buffer;
+
   };
   this.encodeUdt = function (value, udtInfo) {
     const parts = [];
@@ -1347,6 +1386,7 @@ function setEncoders() {
     [dataTypes.list]: this.decodeList,
     [dataTypes.map]: this.decodeMap,
     [dataTypes.set]: this.decodeSet,
+    [dataTypes.json]: this.decodeJson,
     [dataTypes.udt]: this.decodeUdt,
     [dataTypes.tuple]: this.decodeTuple
   };
@@ -1376,6 +1416,7 @@ function setEncoders() {
     [dataTypes.list]: this.encodeList,
     [dataTypes.map]: this.encodeMap,
     [dataTypes.set]: this.encodeSet,
+    [dataTypes.json]: this.encodeJson,
     [dataTypes.udt]: this.encodeUdt,
     [dataTypes.tuple]: this.encodeTuple
   };

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -758,9 +758,7 @@ function defineInstanceMembers() {
     return Buffer.concat(parts);
   };
   this.encodeJson = function encodeJson(value){
-
     let jsonString;
-
     //Use a switch to handle other typeof checking in the future
     switch(typeof value){
       case 'string':
@@ -768,30 +766,21 @@ function defineInstanceMembers() {
         // This is valid if a user wants absolute control over the json object they pass for storage
         // Passing an object as a value would leave some risk of the object being modified by the stack after client.execute() is called
         try{
-
-          JSON.parse(value);
-
-          jsonString = value;
-
-          break;
-
+        	JSON.parse(value);
+        	jsonString = value;
+        	break;
         }
         catch(err){ }
       default:
         jsonString = JSON.stringify(value);
     }
-
     //Get byte length of jsonString
     const jsonStringByteLength = Buffer.byteLength(jsonString);
-
     //Use Unsafe since we are writing in its entirety
     const buffer = utils.allocBufferUnsafe(jsonStringByteLength);
-
     //Write to buffer (pass length to save a tick)
     buffer.write(jsonString, 0, jsonStringByteLength, 'utf8');
-
     return buffer;
-
   };
   this.encodeUdt = function (value, udtInfo) {
     const parts = [];

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -118,6 +118,7 @@ const dataTypes = {
   set:        0x0022,
   udt:        0x0030,
   tuple:      0x0031,
+  json:       0x0080,
   /**
    * Returns the typeInfo of a given type name
    * @param name

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -33,7 +33,11 @@ describe('encoder', function () {
       assertGuessed(new types.Tuple(1, 2, 3), dataTypes.tuple, 'Guess type for a tuple value failed');
       assertGuessed(new types.LocalDate(2010, 4, 29), dataTypes.date, 'Guess type for a date value failed');
       assertGuessed(new types.LocalTime(types.Long.fromString('6331999999911')), dataTypes.time, 'Guess type for a time value failed');
-      assertGuessed({}, null, 'Objects must not be guessed');
+      assertGuessed({}, dataTypes.json, 'Guess type for object failed.');
+      assertGuessed(new Object(), dataTypes.json, 'Guess type for object failed.');
+      assertGuessed(new Object(null), dataTypes.json, 'Guess type for object failed.');
+      assertGuessed(new Object(new Object()), dataTypes.json, 'Guess type for object failed.');
+      assertGuessed(null, null, 'Guess type for null failed.');
     });
     function assertGuessed(value, expectedType, message) {
       const type = Encoder.guessDataType(value);
@@ -79,11 +83,6 @@ describe('encoder', function () {
       const unHinted = typeEncoder.encode();
       assert.strictEqual(hinted, null);
       assert.strictEqual(unHinted, null);
-    });
-    it('should throw on unknown types', function () {
-      assert.throws(function () {
-        typeEncoder.encode({});
-      }, TypeError);
     });
     it('should throw when the typeInfo and the value source type does not match', function () {
       assert.throws(function () {
@@ -485,6 +484,24 @@ describe('encoder', function () {
         assert.strictEqual(decoded.toString(), m.toString());
       });
     });
+    it('should encode/decode json primitives', function(){
+      const encoder = new Encoder(3, {});
+      const type = { code: dataTypes.json, info: null};
+      let encoded, decoded;
+      [null, 12345, 'abcdef', true, false].forEach((v) => {
+        encoded = encoder.encode(v, type);
+        decoded = encoder.decode(encoded, type);
+        assert.strictEqual(decoded, v);
+      });
+    });
+    t('should encode/decode json complex values', function(){
+      const encoder = new Encoder(3, {});
+      const type = { code: dataTypes.json, info: null};
+      const value = { a: 1, b: 'z', c: null, d: true, e: false, f: { a1: 'abc', b1: 123}, g: [1, 'a', null, true, false, {a2: 'def', b2: 456}]};
+      const encoded = encoder.encode(value, type);
+      const decoded = encoder.decode(encoded, type);
+      assert.deepEqual(value,decoded);
+    });
     it('should encode/decode udts', function () {
       const encoder = new Encoder(3, {});
       const type = { code: dataTypes.udt, info: { fields:[
@@ -604,7 +621,7 @@ describe('encoder', function () {
     });
   });
   describe('#encode()', function () {
-    it('should return null when value is null', function () {
+    it('should return json when value is null', function () {
       const encoder = new Encoder(2, {});
       assert.strictEqual(encoder.encode(null), null);
     });

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -621,7 +621,7 @@ describe('encoder', function () {
     });
   });
   describe('#encode()', function () {
-    it('should return json when value is null', function () {
+    it('should return null when value is null', function () {
       const encoder = new Encoder(2, {});
       assert.strictEqual(encoder.encode(null), null);
     });

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -494,7 +494,7 @@ describe('encoder', function () {
         assert.strictEqual(decoded, v);
       });
     });
-    t('should encode/decode json complex values', function(){
+    it('should encode/decode json complex values', function(){
       const encoder = new Encoder(3, {});
       const type = { code: dataTypes.json, info: null};
       const value = { a: 1, b: 'z', c: null, d: true, e: false, f: { a1: 'abc', b1: 123}, g: [1, 'a', null, true, false, {a2: 'def', b2: 456}]};


### PR DESCRIPTION
Made sure to support JSON strings as values (not just objects) so that someone could stringify their own objects (and avoid risking post execution changes to an object they provided to be serialized).

Still need to add test cases. Getting a PR started to start the discussion.